### PR TITLE
fix: table header re-render per request sub

### DIFF
--- a/src/components/data-source/DataSourceRequestTable.re
+++ b/src/components/data-source/DataSourceRequestTable.re
@@ -157,126 +157,130 @@ let make = (~dataSourceID: ID.DataSource.t) => {
     {switch (totalRequestCountSub) {
      | Data(totalRequestCount) when totalRequestCount > 0 =>
        let pageCount = Page.getPageCount(totalRequestCount, pageSize);
-       switch (requestsSub) {
-       | Data(requests) =>
-         <>
-           {isMobile
-              ? <Row marginBottom=16>
-                  <Col>
-                    <div className={CssHelper.flexBox()}>
+       <>
+         {isMobile
+            ? <Row marginBottom=16>
+                <Col>
+                  <div className={CssHelper.flexBox()}>
+                    <Text
+                      block=true
+                      value={totalRequestCount |> Format.iPretty}
+                      weight=Text.Semibold
+                      size=Text.Sm
+                    />
+                    <HSpacing size=Spacing.xs />
+                    <Text
+                      block=true
+                      value="Requests"
+                      weight=Text.Semibold
+                      size=Text.Sm
+                      transform=Text.Uppercase
+                    />
+                  </div>
+                </Col>
+              </Row>
+            : <>
+                <THead>
+                  <Row alignItems=Row.Center>
+                    <Col col=Col.Two>
+                      <div className={CssHelper.flexBox()}>
+                        <Text
+                          block=true
+                          value={totalRequestCount |> Format.iPretty}
+                          weight=Text.Semibold
+                          transform=Text.Uppercase
+                          size=Text.Sm
+                        />
+                        <HSpacing size=Spacing.xs />
+                        <Text
+                          block=true
+                          value="Requests"
+                          weight=Text.Semibold
+                          transform=Text.Uppercase
+                          size=Text.Sm
+                        />
+                      </div>
+                    </Col>
+                    <Col col=Col.Two>
                       <Text
                         block=true
-                        value={totalRequestCount |> Format.iPretty}
+                        value="Fee Earned"
                         weight=Text.Semibold
+                        transform=Text.Uppercase
                         size=Text.Sm
                       />
-                      <HSpacing size=Spacing.xs />
+                    </Col>
+                    <Col col=Col.Three>
                       <Text
                         block=true
-                        value="Requests"
+                        value="Oracle Script"
                         weight=Text.Semibold
+                        transform=Text.Uppercase
                         size=Text.Sm
+                      />
+                    </Col>
+                    <Col col=Col.Three>
+                      <Text
+                        block=true
+                        value="Report Status"
+                        size=Text.Sm
+                        weight=Text.Semibold
                         transform=Text.Uppercase
                       />
-                    </div>
-                  </Col>
-                </Row>
-              : <>
-                  <THead>
-                    <Row alignItems=Row.Center>
-                      <Col col=Col.Two>
-                        <div className={CssHelper.flexBox()}>
-                          <Text
-                            block=true
-                            value={totalRequestCount |> Format.iPretty}
-                            weight=Text.Semibold
-                            transform=Text.Uppercase
-                            size=Text.Sm
-                          />
-                          <HSpacing size=Spacing.xs />
-                          <Text
-                            block=true
-                            value="Requests"
-                            weight=Text.Semibold
-                            transform=Text.Uppercase
-                            size=Text.Sm
-                          />
-                        </div>
-                      </Col>
-                      <Col col=Col.Two>
-                        <Text
-                          block=true
-                          value="Fee Earned"
-                          weight=Text.Semibold
-                          transform=Text.Uppercase
-                          size=Text.Sm
-                        />
-                      </Col>
-                      <Col col=Col.Three>
-                        <Text
-                          block=true
-                          value="Oracle Script"
-                          weight=Text.Semibold
-                          transform=Text.Uppercase
-                          size=Text.Sm
-                        />
-                      </Col>
-                      <Col col=Col.Three>
-                        <Text
-                          block=true
-                          value="Report Status"
-                          size=Text.Sm
-                          weight=Text.Semibold
-                          transform=Text.Uppercase
-                        />
-                      </Col>
-                      <Col col=Col.Two>
-                        <Text
-                          block=true
-                          value="Timestamp"
-                          weight=Text.Semibold
-                          size=Text.Sm
-                          align=Text.Right
-                          transform=Text.Uppercase
-                        />
-                      </Col>
-                    </Row>
-                  </THead>
-                </>}
-           <>
-             {requests
-              ->Belt_Array.mapWithIndex((i, e) =>
-                  isMobile
-                    ? <RenderBodyMobile
-                        key={e.id |> ID.Request.toString}
-                        reserveIndex=i
-                        requestsSub={Sub.resolve(e)}
+                    </Col>
+                    <Col col=Col.Two>
+                      <Text
+                        block=true
+                        value="Timestamp"
+                        weight=Text.Semibold
+                        size=Text.Sm
+                        align=Text.Right
+                        transform=Text.Uppercase
                       />
-                    : <RenderBody
-                        key={e.id |> ID.Request.toString}
-                        theme
-                        requestsSub={Sub.resolve(e)}
-                      />
-                )
-              ->React.array}
-           </>
-           {isMobile
-              ? React.null
-              : <Pagination
-                  currentPage=page
-                  pageCount
-                  onPageChange={newPage => setPage(_ => newPage)}
-                />}
-         </>
-       | _ =>
-         Belt_Array.make(pageSize, ApolloHooks.Subscription.NoData)
-         ->Belt_Array.mapWithIndex((i, noData) =>
-             isMobile
-               ? <RenderBodyMobile key={i |> string_of_int} reserveIndex=i requestsSub=noData />
-               : <RenderBody key={i |> string_of_int} theme requestsSub=noData />
-           )
-         ->React.array
-       };
+                    </Col>
+                  </Row>
+                </THead>
+              </>}
+         {switch (requestsSub) {
+          | Data(requests) =>
+            <>
+              {requests
+               ->Belt_Array.mapWithIndex((i, e) =>
+                   isMobile
+                     ? <RenderBodyMobile
+                         key={e.id |> ID.Request.toString}
+                         reserveIndex=i
+                         requestsSub={Sub.resolve(e)}
+                       />
+                     : <RenderBody
+                         key={e.id |> ID.Request.toString}
+                         theme
+                         requestsSub={Sub.resolve(e)}
+                       />
+                 )
+               ->React.array}
+              {isMobile
+                 ? React.null
+                 : <Pagination
+                     currentPage=page
+                     pageCount
+                     onPageChange={newPage => setPage(_ => newPage)}
+                   />}
+            </>
+          | _ =>
+            Belt_Array.make(pageSize, ApolloHooks.Subscription.NoData)
+            ->Belt_Array.mapWithIndex((i, noData) =>
+                isMobile
+                  ? <RenderBodyMobile
+                      key={i |> string_of_int}
+                      reserveIndex=i
+                      requestsSub=noData
+                    />
+                  : <RenderBody key={i |> string_of_int} theme requestsSub=noData />
+              )
+            ->React.array
+          }}
+       </>;
      | Data(totalRequestCount) when totalRequestCount === 0 =>
        <EmptyContainer>
          <img

--- a/src/components/oracle-script/OracleScriptRequestTable.re
+++ b/src/components/oracle-script/OracleScriptRequestTable.re
@@ -135,12 +135,31 @@ let make = (~oracleScriptID: ID.OracleScript.t) => {
     {switch (totalRequestCountSub) {
      | Data(totalRequestCount) when totalRequestCount > 0 =>
        let pageCount = Page.getPageCount(totalRequestCount, pageSize);
-       switch (requestsSub) {
-       | Data(requests) =>
-         <>
-           {isMobile
-              ? <Row marginBottom=16>
-                  <Col>
+       <>
+         {isMobile
+            ? <Row marginBottom=16>
+                <Col>
+                  <div className={CssHelper.flexBox()}>
+                    <Text
+                      block=true
+                      value={totalRequestCount |> Format.iPretty}
+                      weight=Text.Semibold
+                      size=Text.Sm
+                    />
+                    <HSpacing size=Spacing.xs />
+                    <Text
+                      block=true
+                      value="Requests"
+                      weight=Text.Semibold
+                      size=Text.Sm
+                      transform=Text.Uppercase
+                    />
+                  </div>
+                </Col>
+              </Row>
+            : <THead>
+                <Row alignItems=Row.Center>
+                  <Col col=Col.Two>
                     <div className={CssHelper.flexBox()}>
                       <Text
                         block=true
@@ -158,85 +177,75 @@ let make = (~oracleScriptID: ID.OracleScript.t) => {
                       />
                     </div>
                   </Col>
+                  <Col col=Col.Four>
+                    <Text
+                      block=true
+                      value="Tx Hash"
+                      weight=Text.Semibold
+                      size=Text.Sm
+                      transform=Text.Uppercase
+                    />
+                  </Col>
+                  <Col col=Col.Four>
+                    <Text
+                      block=true
+                      value="Report Status"
+                      weight=Text.Semibold
+                      size=Text.Sm
+                      transform=Text.Uppercase
+                    />
+                  </Col>
+                  <Col col=Col.Two>
+                    <Text
+                      block=true
+                      value="Timestamp"
+                      weight=Text.Semibold
+                      size=Text.Sm
+                      transform=Text.Uppercase
+                      align=Text.Right
+                    />
+                  </Col>
                 </Row>
-              : <THead>
-                  <Row alignItems=Row.Center>
-                    <Col col=Col.Two>
-                      <div className={CssHelper.flexBox()}>
-                        <Text
-                          block=true
-                          value={totalRequestCount |> Format.iPretty}
-                          weight=Text.Semibold
-                          size=Text.Sm
-                        />
-                        <HSpacing size=Spacing.xs />
-                        <Text
-                          block=true
-                          value="Requests"
-                          weight=Text.Semibold
-                          size=Text.Sm
-                          transform=Text.Uppercase
-                        />
-                      </div>
-                    </Col>
-                    <Col col=Col.Four>
-                      <Text
-                        block=true
-                        value="Tx Hash"
-                        weight=Text.Semibold
-                        size=Text.Sm
-                        transform=Text.Uppercase
-                      />
-                    </Col>
-                    <Col col=Col.Four>
-                      <Text
-                        block=true
-                        value="Report Status"
-                        weight=Text.Semibold
-                        size=Text.Sm
-                        transform=Text.Uppercase
-                      />
-                    </Col>
-                    <Col col=Col.Two>
-                      <Text
-                        block=true
-                        value="Timestamp"
-                        weight=Text.Semibold
-                        size=Text.Sm
-                        transform=Text.Uppercase
-                        align=Text.Right
-                      />
-                    </Col>
-                  </Row>
-                </THead>}
-           {requests
-            ->Belt_Array.mapWithIndex((i, e) =>
+              </THead>}
+         {switch (requestsSub) {
+          | Data(requests) =>
+            <>
+              {requests
+               ->Belt_Array.mapWithIndex((i, e) =>
+                   isMobile
+                     ? <RenderBodyMobile
+                         reserveIndex=i
+                         key={e.id |> ID.Request.toString}
+                         requestsSub={Sub.resolve(e)}
+                       />
+                     : <RenderBody
+                         key={e.id |> ID.Request.toString}
+                         requestsSub={Sub.resolve(e)}
+                       />
+                 )
+               ->React.array}
+              {isMobile
+                 ? React.null
+                 : <Pagination
+                     currentPage=page
+                     pageCount
+                     onPageChange={newPage => setPage(_ => newPage)}
+                   />}
+            </>
+          | _ =>
+            Belt_Array.make(pageSize, ApolloHooks.Subscription.NoData)
+            ->Belt_Array.mapWithIndex((i, noData) =>
                 isMobile
                   ? <RenderBodyMobile
                       reserveIndex=i
-                      key={e.id |> ID.Request.toString}
-                      requestsSub={Sub.resolve(e)}
+                      key={i |> string_of_int}
+                      requestsSub=noData
                     />
-                  : <RenderBody key={e.id |> ID.Request.toString} requestsSub={Sub.resolve(e)} />
+                  : <RenderBody key={i |> string_of_int} requestsSub=noData />
               )
-            ->React.array}
-           {isMobile
-              ? React.null
-              : <Pagination
-                  currentPage=page
-                  pageCount
-                  onPageChange={newPage => setPage(_ => newPage)}
-                />}
-         </>
-       | _ =>
-         Belt_Array.make(pageSize, ApolloHooks.Subscription.NoData)
-         ->Belt_Array.mapWithIndex((i, noData) =>
-             isMobile
-               ? <RenderBodyMobile reserveIndex=i key={i |> string_of_int} requestsSub=noData />
-               : <RenderBody key={i |> string_of_int} requestsSub=noData />
-           )
-         ->React.array
-       };
+            ->React.array
+          }}
+       </>;
      | Data(totalRequestCount) when totalRequestCount === 0 =>
        <EmptyContainer>
          <img


### PR DESCRIPTION
### Issue: Reported by Me

### What is the feature?
There's a broken table header appear in the middle of the table's body.

### What is the solution?
Re-arrange the code. Exclude the table header code from the RequestSub

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


### How to test?
[Open](https://cosmoscan.io/data-source/20) and it shouldn't have a table header in the middle of the table when clicking on next pagination.

### Screenshots (if any)
![Screenshot (1)](https://user-images.githubusercontent.com/12908129/155065611-f3117aaf-000e-4912-9f3e-540137a32636.png)


### Other Notes
-
