### PR TITLE
Use dynamic year in footer section

### DIFF
--- a/src/components/Footer.re
+++ b/src/components/Footer.re
@@ -20,6 +20,9 @@ let mapImages = [|
   [|{j|https://www.coingecko.com/en/coins/band-protocol|j}, Images.coingeckoSvg, "CoinGecko"|],
 |];
 
+let currentYear = Js.Date.getFullYear(Js.Date.make());
+let yearString = Js.Float.toString(currentYear);
+
 [@react.component]
 let make = () => {
   let ({ThemeContext.theme}, _) = React.useContext(ThemeContext.context);
@@ -54,7 +57,7 @@ let make = () => {
             <HSpacing size={`px(5)} />
             <Icon name="far fa-copyright" color={theme.white} />
             <HSpacing size={`px(5)} />
-            <Text block=true value="2021" weight=Text.Semibold color={theme.white} />
+            <Text block=true value=yearString weight=Text.Semibold color={theme.white} />
           </div>
         </Col>
       </Row>


### PR DESCRIPTION
### Issue: https://bandprotocol.atlassian.net/jira/software/projects/DEXP/boards/13?selectedIssue=DEXP-403
### What is the feature?
Current year in footer section is hardcoded

### What is the solution?
Get dynamic year from Js.Date instead of hardcoding in footer section

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How to test?
See footer section in deploy preview

### Screenshots (if any)
<img width="1512" alt="Screen Shot 2565-02-28 at 19 42 03" src="https://user-images.githubusercontent.com/52099595/155985981-a94cee0d-6238-4522-bf21-6ab8865a2684.png">


