### PR TITLE
feat: change prepareGas and executeGas to optional parameters

### DIFF
--- a/src/bindings/BandChainJS.re
+++ b/src/bindings/BandChainJS.re
@@ -72,7 +72,9 @@ module MsgVote = {
 
 module MsgRequest = {
   [@bs.module "@bandprotocol/bandchain.js"] [@bs.scope "Message"] [@bs.new]
-  external create: (int, JsBuffer.t, int, int, string, string, array(Coin.t), int, int) => msg_t =
+  external create:
+    (int, JsBuffer.t, int, int, string, string, array(Coin.t), option(int), option(int)) =>
+    msg_t =
     "MsgRequestData";
 };
 

--- a/src/components/oracle-script/OracleScriptExecute.re
+++ b/src/components/oracle-script/OracleScriptExecute.re
@@ -305,8 +305,8 @@ module ExecutionPart = {
     let (callDataArr, setCallDataArr) = React.useState(_ => Belt_Array.make(numParams, ""));
     let (clientID, setClientID) = React.useState(_ => "from_scan");
     let (feeLimit, setFeeLimit) = React.useState(_ => "100");
-    let (prepareGas, setPrepareGas) = React.useState(_ => "30000");
-    let (executeGas, setExecuteGas) = React.useState(_ => "50000");
+    let (prepareGas, setPrepareGas) = React.useState(_ => "");
+    let (executeGas, setExecuteGas) = React.useState(_ => "");
     let (askCount, setAskCount) = React.useState(_ => "1");
     let (minCount, setMinCount) = React.useState(_ => "1");
     let (result, setResult) = React.useState(_ => Nothing);
@@ -389,8 +389,18 @@ module ExecutionPart = {
                    </div>}
               <ClientIDInput clientID setClientID />
               <ValueInput value=feeLimit setValue=setFeeLimit title="Fee Limit" info="(uband)" />
-              <ValueInput value=prepareGas setValue=setPrepareGas title="Prepare Gas" />
-              <ValueInput value=executeGas setValue=setExecuteGas title="Execute Gas" />
+              <ValueInput
+                value=prepareGas
+                setValue=setPrepareGas
+                title="Prepare Gas"
+                info="(optional)"
+              />
+              <ValueInput
+                value=executeGas
+                setValue=setExecuteGas
+                title="Execute Gas"
+                info="(optional)"
+              />
               <SeperatedLine />
               {switch (validatorCount) {
                | Data(count) =>

--- a/src/contexts/AccountContext.re
+++ b/src/contexts/AccountContext.re
@@ -69,8 +69,18 @@ let reducer = state =>
                   sender: address,
                   clientID,
                   feeLimitList: [|feeLimitCoin|],
-                  prepareGas: prepareGas |> int_of_string,
-                  executeGas: executeGas |> int_of_string,
+                  prepareGas: {
+                    switch (prepareGas) {
+                    | "" => None
+                    | _ => Some(prepareGas |> int_of_string)
+                    };
+                  },
+                  executeGas: {
+                    switch (executeGas) {
+                    | "" => None
+                    | _ => Some(executeGas |> int_of_string)
+                    };
+                  },
                 }),
               |],
               ~chainID,

--- a/src/wallet/TxCreator2.re
+++ b/src/wallet/TxCreator2.re
@@ -6,8 +6,8 @@ type request_params_t = {
   clientID: string,
   sender: Address.t,
   feeLimitList: array(BandChainJS.Coin.t),
-  prepareGas: int,
-  executeGas: int,
+  prepareGas: option(int),
+  executeGas: option(int),
 };
 
 type ibc_transfer_t = {


### PR DESCRIPTION
### Issue: 
[DEXP-364](https://bandprotocol.atlassian.net/jira/software/projects/DEXP/boards/13?selectedIssue=DEXP-364)

### What is the feature?
User is able to create an oracle message request without entering a value on `prepareGas` and `executeGas` fields.

### What is the solution?
Change type of `prepareGas` and `executeGas` of `MsgRequestData` to an optional parameter.

### Type of change

- [x] New feature (non-breaking change which adds functionality)

### How to test?
1. Go to https://deploy-preview-171--laozi-testnet4.netlify.app/oracle-script/37
2. Make an oracle request and leave the prepare gas and execute gas fields as a blank value.

### Screenshots (if any)
![Screenshot (4)](https://user-images.githubusercontent.com/12908129/157062308-ce25b763-699a-41e6-b51c-a11bd39126cf.png)

