### PR TITLE
fix: sort by datasource order by request stat

### DIFF
--- a/src/pages/DataSourceHomePage.re
+++ b/src/pages/DataSourceHomePage.re
@@ -42,6 +42,7 @@ let sorting = (dataSources: array(DataSourceSub.t), sortedBy) => {
 module RenderBody = {
   [@react.component]
   let make = (~reserveIndex, ~dataSourcesSub: ApolloHooks.Subscription.variant(DataSourceSub.t)) => {
+    // let now = 1569852318 |> MomentRe.momentWithUnix;
     let ({ThemeContext.theme}, _) = React.useContext(ThemeContext.context);
 
     <TBody

--- a/src/pages/DataSourceHomePage.re
+++ b/src/pages/DataSourceHomePage.re
@@ -42,7 +42,6 @@ let sorting = (dataSources: array(DataSourceSub.t), sortedBy) => {
 module RenderBody = {
   [@react.component]
   let make = (~reserveIndex, ~dataSourcesSub: ApolloHooks.Subscription.variant(DataSourceSub.t)) => {
-    // let now = 1569852318 |> MomentRe.momentWithUnix;
     let ({ThemeContext.theme}, _) = React.useContext(ThemeContext.context);
 
     <TBody

--- a/src/subscriptions/DataSourceSub.re
+++ b/src/subscriptions/DataSourceSub.re
@@ -60,7 +60,7 @@ let toExternal =
 module MultiConfig = [%graphql
   {|
   subscription DataSources($limit: Int!, $offset: Int!, $searchTerm: String!) {
-    data_sources(limit: $limit, offset: $offset, where: {name: {_ilike: $searchTerm}}, order_by: {transaction: {block: {timestamp: desc}}, id: desc}) @bsRecord {
+    data_sources(limit: $limit, offset: $offset, where: {name: {_ilike: $searchTerm}}, order_by: {request_stat: { count: desc }}) @bsRecord {
       id @bsDecoder(fn: "ID.DataSource.fromInt")
       owner @bsDecoder(fn: "Address.fromBech32")
       treasury @bsDecoder(fn: "Address.fromBech32")

--- a/src/subscriptions/DataSourceSub.re
+++ b/src/subscriptions/DataSourceSub.re
@@ -60,7 +60,7 @@ let toExternal =
 module MultiConfig = [%graphql
   {|
   subscription DataSources($limit: Int!, $offset: Int!, $searchTerm: String!) {
-    data_sources(limit: $limit, offset: $offset, where: {name: {_ilike: $searchTerm}}, order_by: {request_stat: { count: desc }}) @bsRecord {
+    data_sources(limit: $limit, offset: $offset, where: {name: {_ilike: $searchTerm}}, order_by: {transaction: {block: {timestamp: desc_nulls_last}}, id: desc}) @bsRecord {
       id @bsDecoder(fn: "ID.DataSource.fromInt")
       owner @bsDecoder(fn: "Address.fromBech32")
       treasury @bsDecoder(fn: "Address.fromBech32")


### PR DESCRIPTION
### Issue: (Jira issue Number or URL)
[https://bandprotocol.atlassian.net/jira/software/projects/DEXP/boards/13?selectedIssue=DEXP-427](https://bandprotocol.atlassian.net/jira/software/projects/DEXP/boards/13?selectedIssue=DEXP-427)

### What is the feature?
Sort By dropdown not working for the old data sources that migrated from the old chains

### What is the solution?
Adjust the data sources subscription to be sorted by the request_stat

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


### How to test?
1. go to the data source page
2. click on the sort by, the table below should be sortable according to the selected sorting option

### Screenshots (if any)


### Other Notes
Add any additional information that would be useful to the developer or QA tester
