### PR TITLE
Add bindings and change tx mode to sendTxSyncMode

### DIFF
--- a/src/bindings/BandChainJS.re
+++ b/src/bindings/BandChainJS.re
@@ -12,6 +12,7 @@ module Client = {
     (t, array(string), int, int) => Js.Promise.t(array(reference_data_t)) =
     "getReferenceData";
   [@bs.send] external sendTxBlockMode: (t, JsBuffer.t) => Js.Promise.t('a) = "sendTxBlockMode";
+  [@bs.send] external sendTxSyncMode: (t, JsBuffer.t) => Js.Promise.t('a) = "sendTxSyncMode";
 };
 
 module PubKey = {

--- a/src/wallet/TxCreator2.re
+++ b/src/wallet/TxCreator2.re
@@ -113,7 +113,7 @@ let createRawTx = (~sender, ~msgs, ~chainID, ~feeAmount, ~gas, ~memo, ~client, (
 };
 
 let broadcast = (client, txRawBytes) => {
-  let%Promise response = client->BandChainJS.Client.sendTxBlockMode(txRawBytes);
+  let%Promise response = client->BandChainJS.Client.sendTxSyncMode(txRawBytes);
   Promise.ret(
     Tx(
       JsonUtils.Decode.{


### PR DESCRIPTION
### Issue: https://bandprotocol.atlassian.net/browse/DEXP-438?atlOrigin=eyJpIjoiZjZmZDYzMTU3MjY3NDE2ZmE5NTU4NGRmM2ExZDgyY2EiLCJwIjoiaiJ9

### What is the feature?
Change send tx mode to sync mode instead of block to prevent broadcast error

### What is the solution?
add bindings and change tx mode to sync

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How to test?
Try doing delegate,undelegate, etc. transactions

