### PR TITLE
Feat/add custom input gas limit

### DIFF
--- a/src/components/modal/submitTx/SubmitTxModal.re
+++ b/src/components/modal/submitTx/SubmitTxModal.re
@@ -88,9 +88,11 @@ module SubmitTxStep = {
     let (show, setShow) = React.useState(_ => false);
     let (msgsOpt, setMsgsOpt) = React.useState(_ => None);
 
+    let gasLimit = SubmitMsg.gasLimit(msg);
+
     let fee = 5000.;
     let (memo, setMemo) = React.useState(_ => EnhanceTxInput.{text: "", value: Some("")});
-    let (gasInput, setGasInput) = React.useState(_ => "300000");
+    let (gasInput, setGasInput) = React.useState(_ => string_of_int(gasLimit));
 
     <div className={Css.merge([Styles.container, Styles.disable(isActive)])}>
       <Heading value={SubmitMsg.toString(msg)} size=Heading.H4 marginBottom=24 />
@@ -138,7 +140,7 @@ module SubmitTxStep = {
         />
         {switch (int_of_string_opt(gasInput)) {
          | Some(gasInputAmout) =>
-           gasInputAmout < 300000
+           gasInputAmout < gasLimit
              ? {
                <div>
                  <Text
@@ -164,7 +166,7 @@ module SubmitTxStep = {
           style=Styles.nextBtn
           disabled={
             switch (int_of_string_opt(gasInput)) {
-            | Some(gasOpt) => gasOpt < 300000 || msgsOpt->Belt.Option.isNone
+            | Some(gasOpt) => gasOpt < gasLimit || msgsOpt->Belt.Option.isNone
             | None => msgsOpt->Belt.Option.isNone
             }
           }
@@ -182,7 +184,7 @@ module SubmitTxStep = {
                    ~gas={
                      switch (int_of_string_opt(gasInput)) {
                      | Some(gasOpt) => gasOpt
-                     | None => SubmitMsg.gasLimit(msg)
+                     | None => gasLimit
                      };
                    },
                    ~memo=memo',

--- a/src/components/modal/submitTx/SubmitTxModal.re
+++ b/src/components/modal/submitTx/SubmitTxModal.re
@@ -88,7 +88,6 @@ module SubmitTxStep = {
     let (show, setShow) = React.useState(_ => false);
     let (msgsOpt, setMsgsOpt) = React.useState(_ => None);
 
-    let gas = SubmitMsg.gasLimit(msg);
     let fee = 5000.;
     let (memo, setMemo) = React.useState(_ => EnhanceTxInput.{text: "", value: Some("")});
     let (gasInput, setGasInput) = React.useState(_ => "");
@@ -172,9 +171,9 @@ module SubmitTxStep = {
                    ~chainID=account.chainID,
                    ~feeAmount=fee |> Js.Float.toString,
                    ~gas={
-                     switch (gasInput) {
-                     | "" => gas
-                     | _ => gasInput |> int_of_string
+                     switch (int_of_string_opt(gasInput)) {
+                     | Some(gasOpt) => gasOpt
+                     | None => SubmitMsg.gasLimit(msg)
                      };
                    },
                    ~memo=memo',

--- a/src/components/modal/submitTx/SubmitTxModal.re
+++ b/src/components/modal/submitTx/SubmitTxModal.re
@@ -42,17 +42,57 @@ module Styles = {
   let nextBtn = style([width(`percent(100.)), marginTop(`px(24))]);
 
   let info = style([display(`flex), justifyContent(`spaceBetween), alignItems(`center)]);
+  let toggle = style([cursor(`pointer), zIndex(100)]);
+  let advancedOptions = (show, theme: Theme.t) => {
+    style([
+      marginTop(`px(10)),
+      transition(~duration=200, "all"),
+      maxHeight(show ? `px(100) : `zero),
+      opacity(show ? 1. : 0.),
+      overflow(`hidden),
+    ]);
+  };
+
+  let listContainer = style([width(`percent(100.)), marginBottom(`px(7))]);
+};
+
+module ValueInput = {
+  [@react.component]
+  let make = (~value, ~setValue, ~title, ~info=?, ~inputType="text") => {
+    let ({ThemeContext.theme}, _) = React.useContext(ThemeContext.context);
+    <div className=Styles.listContainer>
+      <div className={CssHelper.flexBox()}>
+        <Text value=title weight=Text.Semibold transform=Text.Capitalize />
+        <HSpacing size=Spacing.xs />
+        <Text value={info->Belt.Option.getWithDefault("")} weight=Text.Semibold />
+      </div>
+      <VSpacing size=Spacing.sm />
+      <input
+        className={EnhanceTxInput.Styles.input(theme)}
+        type_=inputType
+        onChange={event => {
+          let newVal = ReactEvent.Form.target(event)##value;
+          setValue(_ => newVal);
+        }}
+        value
+      />
+    </div>;
+  };
 };
 
 module SubmitTxStep = {
   [@react.component]
   let make = (~account: AccountContext.t, ~setRawTx, ~isActive, ~msg) => {
+    let (ThemeContext.{theme}, _) = React.useContext(ThemeContext.context);
     let client = React.useContext(ClientContext.context);
+    let (show, setShow) = React.useState(_ => false);
     let (msgsOpt, setMsgsOpt) = React.useState(_ => None);
 
     let gas = SubmitMsg.gasLimit(msg);
     let fee = 5000.;
     let (memo, setMemo) = React.useState(_ => EnhanceTxInput.{text: "", value: Some("")});
+    let (gasInput, setGasInput) = React.useState(_ => "");
+    // let (gasInput, setGasInput) =React.useState(_ => EnhanceTxInput.{text: "", value: Some("")});
 
     <div className={Css.merge([Styles.container, Styles.disable(isActive)])}>
       <Heading value={SubmitMsg.toString(msg)} size=Heading.H4 marginBottom=24 />
@@ -78,6 +118,40 @@ module SubmitTxStep = {
         placeholder="Memo"
         id="memoInput"
       />
+      <div
+        onClick={_ => setShow(prev => !prev)}
+        className={Css.merge([CssHelper.flexBox(~justify=`center, ()), Styles.toggle])}>
+        <Text
+          block=true
+          value={show ? "Hide Advanced Options" : "Show Advanced Options"}
+          weight=Text.Semibold
+          color={theme.textPrimary}
+        />
+        <HSpacing size=Spacing.xs />
+        <Icon name={show ? "fas fa-caret-up" : "fas fa-caret-down"} color={theme.textSecondary} />
+      </div>
+      <div className={Styles.advancedOptions(show, theme)}>
+        <ValueInput
+          value=gasInput
+          setValue=setGasInput
+          title="Gas Limit"
+          info="(optional)"
+          inputType="number"
+        />
+        {switch (int_of_string_opt(gasInput)) {
+         | Some(gasInputAmout) =>
+           gasInputAmout < 200000
+             ? <div>
+                 <Text
+                   value="Gas limit must be at least 200,000"
+                   size=Text.Sm
+                   color=Theme.failColor
+                 />
+               </div>
+             : React.null
+         | _ => React.null
+         }}
+      </div>
       <SeperatedLine />
       <div className=Styles.info>
         <Text value="Transaction Fee" size=Text.Md weight=Text.Medium nowrap=true block=true />
@@ -98,7 +172,12 @@ module SubmitTxStep = {
                    ~msgs,
                    ~chainID=account.chainID,
                    ~feeAmount=fee |> Js.Float.toString,
-                   ~gas,
+                   ~gas={
+                     switch (gasInput) {
+                     | "" => gas
+                     | _ => gasInput |> int_of_string
+                     };
+                   },
                    ~memo=memo',
                    ~client,
                    (),

--- a/src/components/modal/submitTx/SubmitTxModal.re
+++ b/src/components/modal/submitTx/SubmitTxModal.re
@@ -92,7 +92,6 @@ module SubmitTxStep = {
     let fee = 5000.;
     let (memo, setMemo) = React.useState(_ => EnhanceTxInput.{text: "", value: Some("")});
     let (gasInput, setGasInput) = React.useState(_ => "");
-    // let (gasInput, setGasInput) =React.useState(_ => EnhanceTxInput.{text: "", value: Some("")});
 
     <div className={Css.merge([Styles.container, Styles.disable(isActive)])}>
       <Heading value={SubmitMsg.toString(msg)} size=Heading.H4 marginBottom=24 />

--- a/src/components/modal/submitTx/SubmitTxModal.re
+++ b/src/components/modal/submitTx/SubmitTxModal.re
@@ -90,7 +90,7 @@ module SubmitTxStep = {
 
     let fee = 5000.;
     let (memo, setMemo) = React.useState(_ => EnhanceTxInput.{text: "", value: Some("")});
-    let (gasInput, setGasInput) = React.useState(_ => "");
+    let (gasInput, setGasInput) = React.useState(_ => "300000");
 
     <div className={Css.merge([Styles.container, Styles.disable(isActive)])}>
       <Heading value={SubmitMsg.toString(msg)} size=Heading.H4 marginBottom=24 />
@@ -138,15 +138,19 @@ module SubmitTxStep = {
         />
         {switch (int_of_string_opt(gasInput)) {
          | Some(gasInputAmout) =>
-           gasInputAmout < 200000
-             ? <div>
+           gasInputAmout < 300000
+             ? {
+               <div>
                  <Text
-                   value="Gas limit must be at least 200,000"
+                   value="Gas limit must be at least 300,000"
                    size=Text.Sm
                    color=Theme.failColor
                  />
-               </div>
-             : React.null
+               </div>;
+             }
+             : {
+               React.null;
+             }
          | _ => React.null
          }}
       </div>
@@ -158,7 +162,12 @@ module SubmitTxStep = {
       <div id="nextButtonContainer">
         <Button
           style=Styles.nextBtn
-          disabled={msgsOpt->Belt.Option.isNone}
+          disabled={
+            switch (int_of_string_opt(gasInput)) {
+            | Some(gasOpt) => gasOpt < 300000 || msgsOpt->Belt.Option.isNone
+            | None => msgsOpt->Belt.Option.isNone
+            }
+          }
           onClick={_ => {
             let rawTxOpt =
               {let%Opt memo' = memo.value;

--- a/src/pages/NotFound.re
+++ b/src/pages/NotFound.re
@@ -21,7 +21,7 @@ module Styles = {
 
   let rightArrow = style([width(`px(20)), filter([`saturate(50.0), `brightness(70.0)])]);
 
-  let logo = style([width(`px(120)), marginRight(`px(10))]);
+  let logo = style([width(`auto), height(`px(90)), marginRight(`px(10))]);
 };
 
 [@react.component]

--- a/src/pages/TxIndexPage.re
+++ b/src/pages/TxIndexPage.re
@@ -17,7 +17,7 @@ module Styles = {
       borderRadius(`px(8)),
       boxShadow(Shadow.box(~x=`zero, ~y=`px(2), ~blur=`px(4), Css.rgba(0, 0, 0, `num(0.2)))),
     ]);
-  let notfoundLogo = style([width(`px(180)), marginRight(`px(10))]);
+  let notfoundLogo = style([width(`auto), height(`px(90)), marginRight(`px(0))]);
 };
 
 module TxNotFound = {

--- a/src/utils/SubmitMsg.re
+++ b/src/utils/SubmitMsg.re
@@ -24,5 +24,5 @@ let gasLimit =
   | Undelegate(_)
   | Vote(_)
   | WithdrawReward(_)
-  | Reinvest(_) => 200000
+  | Reinvest(_)
   | Redelegate(_) => 300000;


### PR DESCRIPTION
### Issue: (Jira issue Number or URL)
[https://bandprotocol.atlassian.net/browse/DEXP-440?atlOrigin=eyJpIjoiNmUxNmE2NzRhZWJlNDA5NzgyN2I0ZTFlNjAyYTNjMjMiLCJwIjoiaiJ9](https://bandprotocol.atlassian.net/browse/DEXP-440?atlOrigin=eyJpIjoiNmUxNmE2NzRhZWJlNDA5NzgyN2I0ZTFlNjAyYTNjMjMiLCJwIjoiaiJ9)

### What is the feature?
Users are able to adjust the gas limit of each request message.

### What is the solution?
Add a new input field and validate the gas limit to be more than 200000

### Type of change

- [x] New feature (non-breaking change which adds functionality)

### How to test?
Send any message in cosmoscan

### Screenshots (if any)
![https://user-images.githubusercontent.com/12908129/161097769-66f4018c-5ee7-46d4-9977-7dccfca7f712.png](https://user-images.githubusercontent.com/12908129/161097769-66f4018c-5ee7-46d4-9977-7dccfca7f712.png)



### Other Notes
Add any additional information that would be useful to the developer or QA tester
