### PR TITLE
feat: add gaslimit input field on make an os request (Testnet Only)

### DIFF
--- a/src/components/oracle-script/OracleScriptExecute.re
+++ b/src/components/oracle-script/OracleScriptExecute.re
@@ -307,6 +307,7 @@ module ExecutionPart = {
     let (feeLimit, setFeeLimit) = React.useState(_ => "100");
     let (prepareGas, setPrepareGas) = React.useState(_ => "");
     let (executeGas, setExecuteGas) = React.useState(_ => "");
+    let (gaslimit, setGaslimit) = React.useState(_ => "");
     let (askCount, setAskCount) = React.useState(_ => "1");
     let (minCount, setMinCount) = React.useState(_ => "1");
     let (result, setResult) = React.useState(_ => Nothing);
@@ -401,6 +402,12 @@ module ExecutionPart = {
                 title="Execute Gas"
                 info="(optional)"
               />
+              <ValueInput
+                value=gaslimit
+                setValue=setGaslimit
+                title="Gas Limit"
+                info="(optional)"
+              />
               <SeperatedLine />
               {switch (validatorCount) {
                | Data(count) =>
@@ -449,6 +456,7 @@ module ExecutionPart = {
                                  feeLimit,
                                  prepareGas,
                                  executeGas,
+                                 gaslimit,
                                },
                                client,
                              ),

--- a/src/contexts/AccountContext.re
+++ b/src/contexts/AccountContext.re
@@ -15,6 +15,7 @@ type send_request_t = {
   feeLimit: string,
   prepareGas: string,
   executeGas: string,
+  gaslimit: string,
 };
 
 type a =
@@ -43,6 +44,7 @@ let reducer = state =>
         feeLimit,
         prepareGas,
         executeGas,
+        gaslimit,
       },
       client,
     ) =>
@@ -84,7 +86,12 @@ let reducer = state =>
                 }),
               |],
               ~chainID,
-              ~gas=700000,
+              ~gas={
+                switch (int_of_string_opt(gaslimit)) {
+                | Some(gasOpt) => gasOpt
+                | _ => 700000
+                };
+              },
               ~feeAmount="0",
               ~memo="send via scan",
               ~client,


### PR DESCRIPTION
### Issue: (Jira issue Number or URL)
[https://bandprotocol.atlassian.net/jira/software/projects/DEXP/boards/13?selectedIssue=DEXP-433](https://bandprotocol.atlassian.net/jira/software/projects/DEXP/boards/13?selectedIssue=DEXP-433)

### What is the feature?
Users able to adjust gas limit when they create a new OS request

### What is the solution?
Add a new input field and have the default value to 700000

### Type of change

- [x] New feature (non-breaking change which adds functionality)


### Screenshots (if any)
![Screenshot (11)](https://user-images.githubusercontent.com/12908129/162152211-218be54c-c0c8-48ad-b760-a28afdc53932.png)

