### PR TITLE
hotfix: change parsing coin type

### DIFF
--- a/src/subscriptions/GraphQLParser.re
+++ b/src/subscriptions/GraphQLParser.re
@@ -86,8 +86,8 @@ let floatExn = jsonOpt => {
 
 let coinWithDefault = jsonOpt => {
   jsonOpt
-  |> Belt_Option.flatMap(_, Js.Json.decodeNumber)
-  |> Belt.Option.getWithDefault(_, 0.0)
+  |> Belt_Option.flatMap(_, Js.Json.decodeString)
+  |> Belt.Option.mapWithDefault(_, 0., float_of_string)
   |> Coin.newUBANDFromAmount;
 };
 


### PR DESCRIPTION
### Issue: (Jira issue Number or URL)
As reported by @pzshine and @taobun 

### What is the feature?
this is the hotfix pr for the function `coinWithDefault` to expect the JSON decode type string instead of the number.
This is happened on Mainnet

### What is the solution?
changed `Js.Json.decodeNumber` to  `Js.Json.decodeString`


### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Screenshots (if any)
<img width="1354" alt="Screen Shot 2565-08-01 at 00 10 59" src="https://user-images.githubusercontent.com/12908129/182037686-e6477e33-289d-4709-8727-6ef2b06fefd0.png">
<img width="612" alt="Screen Shot 2565-08-01 at 00 10 45" src="https://user-images.githubusercontent.com/12908129/182037691-4b227c60-7651-4b5a-8c07-671fb488f2df.png">

### Other Notes
Go to these pages for testing
https://cosmoscan.io/validator/bandvaloper1r00x80djyu6wkxpceegmvn5w9nx65prgqhxkzq#reports
https://cosmoscan.io/proposal/6
