### PR TITLE
fix: add support hasura new version non-null value

### DIFF
--- a/src/query/IBCQuery.re
+++ b/src/query/IBCQuery.re
@@ -166,8 +166,8 @@ let toExternal =
 };
 module IncomingPacketsConfig = [%graphql
   {|
-  query IncomingPackets($limit: Int!, $packetType: String, $packetTypeIsNull: Boolean, $port: String!, $channel: String!, $sequence: Int, $chainID: String!) {
-    incoming_packets(limit: $limit, order_by: {block_height: desc}, where: {type: {_is_null: $packetTypeIsNull, _ilike: $packetType}, sequence: {_eq: $sequence}, dst_port: {_ilike: $port}, dst_channel: {_ilike: $channel}, channel:{connection: {counterparty_chain: {chain_id: {_ilike: $chainID}}}}}) @bsRecord{
+    query IncomingPackets($limit: Int!, $packetType: String!, $packetTypeIsNull: Boolean!, $port: String!, $channel: String!, $sequence: Int_comparison_exp, $chainID: String!) {
+    incoming_packets(limit: $limit, order_by: {block_height: desc}, where: {type: {_is_null: $packetTypeIsNull, _ilike: $packetType}, sequence: $sequence, dst_port: {_ilike: $port}, dst_channel: {_ilike: $channel}, channel:{connection: {counterparty_chain: {chain_id: {_ilike: $chainID}}}}}) @bsRecord {
         packetType: type @bsDecoder(fn: "parsePacketTypeOpt")
         srcPort: src_port
         srcChannel: src_channel
@@ -192,8 +192,8 @@ module IncomingPacketsConfig = [%graphql
 
 module OutgoingPacketsConfig = [%graphql
   {|
-  query OutgoingPackets($limit: Int!, $packetType: String, $packetTypeIsNull: Boolean, $port: String!, $channel: String!, $sequence: Int, $chainID: String!) {
-    outgoing_packets(limit: $limit, order_by: {block_height: desc}, where: {type: {_is_null: $packetTypeIsNull, _ilike: $packetType}, sequence: {_eq: $sequence} ,src_port: {_ilike: $port}, src_channel: {_ilike: $channel}, channel:{connection: {counterparty_chain: {chain_id: {_ilike: $chainID}}}}}) @bsRecord{
+    query OutgoingPackets($limit: Int!, $packetType: String!, $packetTypeIsNull: Boolean!, $port: String!, $channel: String!, $sequence: Int_comparison_exp, $chainID: String!) {
+    outgoing_packets(limit: $limit, order_by: {block_height: desc}, where: {type: {_is_null: $packetTypeIsNull, _ilike: $packetType}, sequence: $sequence ,src_port: {_ilike: $port}, src_channel: {_ilike: $channel}, channel:{connection: {counterparty_chain: {chain_id: {_ilike: $chainID}}}}}) @bsRecord {
         packetType: type @bsDecoder(fn: "parsePacketTypeOpt")
         srcPort: src_port
         srcChannel: src_channel
@@ -234,6 +234,34 @@ let getList =
     | _ => None
     };
   };
+
+  let sequenceFilter = {
+    switch (sequence) {
+    | Some(_) => {
+        "_eq": sequence,
+        "_gt": None,
+        "_gte": None,
+        "_in": None,
+        "_is_null": None,
+        "_lt": None,
+        "_lte": None,
+        "_neq": None,
+        "_nin": None,
+      }
+    | _ => {
+        "_eq": None,
+        "_gt": None,
+        "_gte": None,
+        "_in": None,
+        "_is_null": None,
+        "_lt": None,
+        "_lte": None,
+        "_neq": None,
+        "_nin": None,
+      }
+    };
+  };
+
   let result =
     switch (direction) {
     | Incoming =>
@@ -243,8 +271,20 @@ let getList =
           ~variables=
             IncomingPacketsConfig.makeVariables(
               ~limit=pageSize,
-              ~packetType=?packetTypeKeyword,
-              ~packetTypeIsNull?,
+              ~packetType={
+                switch (packetTypeKeyword) {
+                | Some("oracle_request") => "oracle_request"
+                | Some("oracle response") => "oracle response"
+                | Some("fungible_token") => "fungible_token"
+                | _ => "%%"
+                };
+              },
+              ~packetTypeIsNull={
+                switch (packetTypeIsNull) {
+                | Some(true) => true
+                | _ => false
+                };
+              },
               ~port={
                 port !== "" ? port : "%%";
               },
@@ -254,7 +294,9 @@ let getList =
               ~chainID={
                 chainID !== "" ? chainID : "%%";
               },
-              ~sequence?,
+              ~sequence={
+                sequenceFilter;
+              },
               (),
             ),
           ~pollInterval=?Some(5000),
@@ -267,8 +309,20 @@ let getList =
           ~variables=
             OutgoingPacketsConfig.makeVariables(
               ~limit=pageSize,
-              ~packetType=?packetTypeKeyword,
-              ~packetTypeIsNull?,
+              ~packetType={
+                switch (packetTypeKeyword) {
+                | Some("oracle_request") => "oracle_request"
+                | Some("oracle response") => "oracle response"
+                | Some("fungible_token") => "fungible_token"
+                | _ => "%%"
+                };
+              },
+              ~packetTypeIsNull={
+                switch (packetTypeIsNull) {
+                | Some(true) => true
+                | _ => false
+                };
+              },
               ~port={
                 port !== "" ? port : "%%";
               },
@@ -278,7 +332,9 @@ let getList =
               ~chainID={
                 chainID !== "" ? chainID : "%%";
               },
-              ~sequence?,
+              ~sequence={
+                sequenceFilter;
+              },
               (),
             ),
           ~pollInterval=?Some(5000),

--- a/src/subscriptions/GraphQLParser.re
+++ b/src/subscriptions/GraphQLParser.re
@@ -86,8 +86,8 @@ let floatExn = jsonOpt => {
 
 let coinWithDefault = jsonOpt => {
   jsonOpt
-  |> Belt_Option.flatMap(_, Js.Json.decodeNumber)
-  |> Belt.Option.getWithDefault(_, 0.0)
+  |> Belt_Option.flatMap(_, Js.Json.decodeString)
+  |> Belt.Option.mapWithDefault(_, 0., float_of_string)
   |> Coin.newUBANDFromAmount;
 };
 

--- a/src/subscriptions/RequestSub.re
+++ b/src/subscriptions/RequestSub.re
@@ -1,5 +1,6 @@
-open ValidatorSub.Mini;
 open TxSub.Mini;
+
+open ValidatorSub.Mini;
 
 type resolve_status_t =
   | Pending


### PR DESCRIPTION
### Issue: (Jira issue Number or URL)
As reported by @pzshine and @taobun 

### What is the feature?
- this is the hotfix pr for the function `coinWithDefault` to expect the JSON decode type string instead of the number.
This incident happened on Mainnet

- Since we've upgrade hasura version to >=1.3.4, many graphql are broken

### What is the solution?
- changed `Js.Json.decodeNumber` to  `Js.Json.decodeString`

- Remove `getExn` from all non-null schema


### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Screenshots (if any)
<img width="1354" alt="Screen Shot 2565-08-01 at 00 10 59" src="https://user-images.githubusercontent.com/12908129/182037686-e6477e33-289d-4709-8727-6ef2b06fefd0.png">
<img width="612" alt="Screen Shot 2565-08-01 at 00 10 45" src="https://user-images.githubusercontent.com/12908129/182037691-4b227c60-7651-4b5a-8c07-671fb488f2df.png">

### Other Notes
Go to these pages for testing
https://cosmoscan.io/validator/bandvaloper1r00x80djyu6wkxpceegmvn5w9nx65prgqhxkzq#reports
https://cosmoscan.io/proposal/6
