### PR TITLE
:sparkles: Add optional hex to [u8] on make request tab in OS page

### DIFF
--- a/__tests__/JsBuffer_test.re
+++ b/__tests__/JsBuffer_test.re
@@ -208,4 +208,8 @@ describe("Expect JsBuffer to work correctly", () => {
          88,
        |])
   );
+  test("should be able to convert hex to string array directly", () =>
+    expect("f23391b5dbf982e37fb7dadea64aae21cae4c172" |> hexToStringArray)
+    |> toEqual("[242,51,145,181,219,249,130,227,127,183,218,222,166,74,174,33,202,228,193,114]")
+  );
 });

--- a/src/bindings/JsBuffer.re
+++ b/src/bindings/JsBuffer.re
@@ -29,3 +29,5 @@ let arrayToHex = arr => arr->from->toHex;
 let hexToArray = hexstr => hexstr->fromHex->toArray;
 let arrayToBase64 = arr => arr->from->toBase64;
 let base64ToArray = base64str => base64str->fromBase64->toArray;
+let hexToStringArray = hex =>
+  hex->hexToArray->Js.Json.stringifyAny->Belt_Option.getWithDefault(hex);

--- a/src/components/oracle-script/OracleScriptExecute.re
+++ b/src/components/oracle-script/OracleScriptExecute.re
@@ -117,7 +117,17 @@ module ParameterInput = {
         className={Styles.input(theme)}
         type_="text"
         onChange={event => {
-          let newVal: string = ReactEvent.Form.target(event)##value;
+          let inputVal: string = ReactEvent.Form.target(event)##value;
+          let newVal =
+            switch (fieldType, Js.String.charAt(0, inputVal) !== "[") {
+            | ("[u8]", true) =>
+              switch (inputVal |> JsBuffer.hexToStringArray) {
+              | value => value
+              | exception _ => inputVal
+              }
+            | (_, _) => inputVal
+            };
+
           setCallDataArr(prev => {
             prev->Belt_Array.mapWithIndex((i, value: string) => {index == i ? newVal : value})
           });


### PR DESCRIPTION
### Issue: (Jira issue Number or URL)

### What is the feature?

Add optional type for input type [u8] on make request tab in OS page

### What is the solution?

Convert from hex to string of array ex.

from `f23391b5dbf982e37fb7dadea64aae21cae4c172` to `"[242,51,145,181,219,249,130,227,127,183,218,222,166,74,174,33,202,228,193,114]"`


### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How to test?
Describe the prerequisites and the steps to test

1. Go to OS#152
2. Click on the make request tab
3. Find some hex (EVM wallet address) 
4. Fill hex in the fields which has type [u8]
5. Click on the Make a request button
6. It should successfully request and get the request number

### Screenshots (if any)


### Other Notes
Add any additional information that would be useful to the developer or QA tester
