### PR TITLE
change bonded token data when proposal finished

### DIFF
--- a/src/pages/ProposalIndexPage.re
+++ b/src/pages/ProposalIndexPage.re
@@ -416,9 +416,9 @@ let make = (~proposalID) => {
                            CssHelper.flexBoxSm(~justify=`spaceAround, ()),
                            CssHelper.flexBox(~justify=`flexEnd, ()),
                          ])}>
-                         {let turnoutPercent = switch (MomentRe.diff(MomentRe.momentNow(),votingEndTime, `seconds) < 0.) {
-                         | true => total /. (bondedToken |> Coin.getBandAmountFromCoin) *. 100.
-                         | false => endTotalVote /. totalBondedTokens  *. 100.
+                         {let turnoutPercent = switch (totalBondedTokens) {
+                         | Some(totalBondedTokensExn) => endTotalVote /. totalBondedTokensExn  *. 100.
+                         | None => total /. (bondedToken |> Coin.getBandAmountFromCoin) *. 100.
                          };
                           <div className=Styles.chartContainer>
                             <TurnoutChart percent=turnoutPercent />
@@ -487,30 +487,8 @@ let make = (~proposalID) => {
                    </div>
                    <SeperatedLine mt=24 mb=35 />
                    <div className=Styles.resultContainer>
-                      { switch (MomentRe.diff(MomentRe.momentNow(),votingEndTime, `seconds) < 0.) {
-                      | true => <>
-                        <ProgressBar.Voting
-                          label=VoteSub.Yes
-                          amount=totalYes
-                          percent=totalYesPercent
-                        />
-                        <ProgressBar.Voting
-                          label=VoteSub.No
-                          amount=totalNo
-                          percent=totalNoPercent
-                        />
-                        <ProgressBar.Voting
-                          label=VoteSub.NoWithVeto
-                          amount=totalNoWithVeto
-                          percent=totalNoWithVetoPercent
-                        />
-                        <ProgressBar.Voting
-                          label=VoteSub.Abstain
-                          amount=totalAbstain
-                          percent=totalAbstainPercent
-                        />
-                      </>
-                      | false => <>
+                      { switch (totalBondedTokens) {
+                      | Some(_) => <>
                         <ProgressBar.Voting
                           label=VoteSub.Yes
                           amount=endTotalYes
@@ -530,6 +508,28 @@ let make = (~proposalID) => {
                           label=VoteSub.Abstain
                           amount=endTotalAbstain
                           percent=endTotalAbstainPercent
+                        />
+                      </>
+                      | None => <>
+                        <ProgressBar.Voting
+                          label=VoteSub.Yes
+                          amount=totalYes
+                          percent=totalYesPercent
+                        />
+                        <ProgressBar.Voting
+                          label=VoteSub.No
+                          amount=totalNo
+                          percent=totalNoPercent
+                        />
+                        <ProgressBar.Voting
+                          label=VoteSub.NoWithVeto
+                          amount=totalNoWithVeto
+                          percent=totalNoWithVetoPercent
+                        />
+                        <ProgressBar.Voting
+                          label=VoteSub.Abstain
+                          amount=totalAbstain
+                          percent=totalAbstainPercent
                         />
                       </>
                       }}

--- a/src/pages/ProposalIndexPage.re
+++ b/src/pages/ProposalIndexPage.re
@@ -369,8 +369,21 @@ let make = (~proposalID) => {
         </Col>
       </Row>
       {switch (allSub) {
-       | Data((
-           {status, votingStartTime, votingEndTime},
+       | Data(({
+            status, 
+            votingStartTime, 
+            votingEndTime, 
+            endTotalYes,
+            endTotalYesPercent,
+            endTotalNo,
+            endTotalNoPercent,
+            endTotalNoWithVeto,
+            endTotalNoWithVetoPercent,
+            endTotalAbstain,
+            endTotalAbstainPercent,
+            endTotalVote,
+            totalBondedTokens,
+           },
            {
              total,
              totalYes,
@@ -403,8 +416,10 @@ let make = (~proposalID) => {
                            CssHelper.flexBoxSm(~justify=`spaceAround, ()),
                            CssHelper.flexBox(~justify=`flexEnd, ()),
                          ])}>
-                         {let turnoutPercent =
-                            total /. (bondedToken |> Coin.getBandAmountFromCoin) *. 100.;
+                         {let turnoutPercent = switch (MomentRe.diff(MomentRe.momentNow(),votingEndTime, `seconds) < 0.) {
+                         | true => total /. (bondedToken |> Coin.getBandAmountFromCoin) *. 100.
+                         | false => endTotalVote /. totalBondedTokens  *. 100.
+                         };
                           <div className=Styles.chartContainer>
                             <TurnoutChart percent=turnoutPercent />
                           </div>}
@@ -419,12 +434,20 @@ let make = (~proposalID) => {
                              color={theme.textSecondary}
                              marginBottom=4
                            />
-                           <Text
-                             value={(total |> Format.fPretty(~digits=2)) ++ " BAND"}
-                             size=Text.Lg
-                             block=true
-                             color={theme.textPrimary}
-                           />
+                           {switch (MomentRe.diff(MomentRe.momentNow(),votingEndTime, `seconds) < 0.) {
+                            | true =>  <Text
+                              value={(total |> Format.fPretty(~digits=2)) ++ " BAND"}
+                              size=Text.Lg
+                              block=true
+                              color={theme.textPrimary}
+                            />
+                            | false => <Text
+                              value={(endTotalVote |> Format.fPretty(~digits=2)) ++ " BAND"}
+                              size=Text.Lg
+                              block=true
+                              color={theme.textPrimary}
+                            />
+                            }}
                          </Col>
                          <Col mb=24 mbSm=0 colSm=Col.Six>
                            <Heading
@@ -464,28 +487,52 @@ let make = (~proposalID) => {
                    </div>
                    <SeperatedLine mt=24 mb=35 />
                    <div className=Styles.resultContainer>
-                     <>
-                       <ProgressBar.Voting
-                         label=VoteSub.Yes
-                         amount=totalYes
-                         percent=totalYesPercent
-                       />
-                       <ProgressBar.Voting
-                         label=VoteSub.No
-                         amount=totalNo
-                         percent=totalNoPercent
-                       />
-                       <ProgressBar.Voting
-                         label=VoteSub.NoWithVeto
-                         amount=totalNoWithVeto
-                         percent=totalNoWithVetoPercent
-                       />
-                       <ProgressBar.Voting
-                         label=VoteSub.Abstain
-                         amount=totalAbstain
-                         percent=totalAbstainPercent
-                       />
-                     </>
+                      { switch (MomentRe.diff(MomentRe.momentNow(),votingEndTime, `seconds) < 0.) {
+                      | true => <>
+                        <ProgressBar.Voting
+                          label=VoteSub.Yes
+                          amount=totalYes
+                          percent=totalYesPercent
+                        />
+                        <ProgressBar.Voting
+                          label=VoteSub.No
+                          amount=totalNo
+                          percent=totalNoPercent
+                        />
+                        <ProgressBar.Voting
+                          label=VoteSub.NoWithVeto
+                          amount=totalNoWithVeto
+                          percent=totalNoWithVetoPercent
+                        />
+                        <ProgressBar.Voting
+                          label=VoteSub.Abstain
+                          amount=totalAbstain
+                          percent=totalAbstainPercent
+                        />
+                      </>
+                      | false => <>
+                        <ProgressBar.Voting
+                          label=VoteSub.Yes
+                          amount=endTotalYes
+                          percent=endTotalYesPercent
+                        />
+                        <ProgressBar.Voting
+                          label=VoteSub.No
+                          amount=endTotalNo
+                          percent=endTotalNoPercent
+                        />
+                        <ProgressBar.Voting
+                          label=VoteSub.NoWithVeto
+                          amount=endTotalNoWithVeto
+                          percent=endTotalNoWithVetoPercent
+                        />
+                        <ProgressBar.Voting
+                          label=VoteSub.Abstain
+                          amount=endTotalAbstain
+                          percent=endTotalAbstainPercent
+                        />
+                      </>
+                      }}
                    </div>
                  </InfoContainer>
                </Col>

--- a/src/subscriptions/GraphQLParser.re
+++ b/src/subscriptions/GraphQLParser.re
@@ -87,6 +87,10 @@ let floatExn = jsonOpt => {
   }) |> float_of_string
 };
 
+let floatOpt = jsonOpt => {
+  jsonOpt |> Belt_Option.flatMap(_, Js.Json.decodeString) |> Belt.Option.map(_, float_of_string)
+};
+
 let coinWithDefault = jsonOpt => {
   jsonOpt
   |> Belt_Option.flatMap(_, Js.Json.decodeString)

--- a/src/subscriptions/GraphQLParser.re
+++ b/src/subscriptions/GraphQLParser.re
@@ -81,7 +81,10 @@ let coinExn = jsonOpt => {
 };
 
 let floatExn = jsonOpt => {
-  jsonOpt |> Belt_Option.flatMap(_, Js.Json.decodeString) |> Belt.Option.getExn |> float_of_string;
+  jsonOpt |> Belt_Option.flatMap(_, Js.Json.decodeString) |> ((opt) => switch (opt) {
+    | Some(value) => value
+    | None => "0"
+  }) |> float_of_string
 };
 
 let coinWithDefault = jsonOpt => {

--- a/src/subscriptions/ProposalSub.re
+++ b/src/subscriptions/ProposalSub.re
@@ -89,7 +89,7 @@ type internal_t = {
   no_vote: float,
   no_with_veto_vote: float,
   abstain_vote: float,
-  total_bonded_tokens: float,
+  total_bonded_tokens: option(float),
   totalDeposit: list(Coin.t),
   
 };
@@ -115,7 +115,7 @@ type t = {
   endTotalAbstain: float,
   endTotalAbstainPercent: float,
   endTotalVote: float,
-  totalBondedTokens: float,
+  totalBondedTokens: option(float),
   totalDeposit: list(Coin.t),
 };
 
@@ -164,7 +164,7 @@ let toExternal =
   endTotalAbstain: abstain_vote /. 1e6,
   endTotalAbstainPercent: abstain_vote /. (yes_vote +. no_vote +. no_with_veto_vote +. abstain_vote) *. 100.,
   endTotalVote: (yes_vote +. no_vote +. no_with_veto_vote +. abstain_vote) /. 1e6,
-  totalBondedTokens: total_bonded_tokens /. 1e6,
+  totalBondedTokens: total_bonded_tokens -> Belt.Option.map(d => d /. 1e6) ,
   totalDeposit,
 };
 
@@ -189,7 +189,7 @@ module MultiConfig = [%graphql
       no_vote @bsDecoder(fn: "GraphQLParser.floatExn")
       no_with_veto_vote @bsDecoder(fn: "GraphQLParser.floatExn")
       abstain_vote @bsDecoder(fn: "GraphQLParser.floatExn")
-      total_bonded_tokens @bsDecoder(fn: "GraphQLParser.floatExn")
+      total_bonded_tokens @bsDecoder(fn: "GraphQLParser.floatOpt")
       totalDeposit: total_deposit @bsDecoder(fn: "GraphQLParser.coins")
     }
   }
@@ -217,7 +217,7 @@ module SingleConfig = [%graphql
       no_vote @bsDecoder(fn: "GraphQLParser.floatExn")
       no_with_veto_vote @bsDecoder(fn: "GraphQLParser.floatExn")
       abstain_vote @bsDecoder(fn: "GraphQLParser.floatExn")
-      total_bonded_tokens @bsDecoder(fn: "GraphQLParser.floatExn")
+      total_bonded_tokens @bsDecoder(fn: "GraphQLParser.floatOpt")
       totalDeposit: total_deposit @bsDecoder(fn: "GraphQLParser.coins")
     }
   }

--- a/src/subscriptions/ProposalSub.re
+++ b/src/subscriptions/ProposalSub.re
@@ -85,7 +85,13 @@ type internal_t = {
   votingEndTime: MomentRe.Moment.t,
   accountOpt: option(account_t),
   proposalType: string,
+  yes_vote: float,
+  no_vote: float,
+  no_with_veto_vote: float,
+  abstain_vote: float,
+  total_bonded_tokens: float,
   totalDeposit: list(Coin.t),
+  
 };
 
 type t = {
@@ -100,6 +106,16 @@ type t = {
   votingEndTime: MomentRe.Moment.t,
   proposerAddressOpt: option(Address.t),
   proposalType: string,
+  endTotalYes: float,
+  endTotalYesPercent: float,
+  endTotalNo: float,
+  endTotalNoPercent: float,
+  endTotalNoWithVeto: float,
+  endTotalNoWithVetoPercent: float,
+  endTotalAbstain: float,
+  endTotalAbstainPercent: float,
+  endTotalVote: float,
+  totalBondedTokens: float,
   totalDeposit: list(Coin.t),
 };
 
@@ -117,6 +133,11 @@ let toExternal =
         votingEndTime,
         accountOpt,
         proposalType,
+        yes_vote,
+        no_vote,
+        no_with_veto_vote,
+        abstain_vote,
+        total_bonded_tokens,
         totalDeposit,
       },
     ) => {
@@ -134,6 +155,16 @@ let toExternal =
   votingEndTime,
   proposerAddressOpt: accountOpt->Belt.Option.map(({address}) => address),
   proposalType,
+  endTotalYes: yes_vote /. 1e6,
+  endTotalYesPercent: yes_vote /. (yes_vote +. no_vote +. no_with_veto_vote +. abstain_vote) *. 100.,
+  endTotalNo: no_vote /. 1e6,
+  endTotalNoPercent: no_vote /. (yes_vote +. no_vote +. no_with_veto_vote +. abstain_vote) *. 100.,
+  endTotalNoWithVeto: no_with_veto_vote /. 1e6,
+  endTotalNoWithVetoPercent: no_with_veto_vote /. (yes_vote +. no_vote +. no_with_veto_vote +. abstain_vote) *. 100.,
+  endTotalAbstain: abstain_vote /. 1e6,
+  endTotalAbstainPercent: abstain_vote /. (yes_vote +. no_vote +. no_with_veto_vote +. abstain_vote) *. 100.,
+  endTotalVote: (yes_vote +. no_vote +. no_with_veto_vote +. abstain_vote) /. 1e6,
+  totalBondedTokens: total_bonded_tokens /. 1e6,
   totalDeposit,
 };
 
@@ -154,6 +185,11 @@ module MultiConfig = [%graphql
       accountOpt: account @bsRecord {
         address @bsDecoder(fn: "Address.fromBech32")
       }
+      yes_vote @bsDecoder(fn: "GraphQLParser.floatExn")
+      no_vote @bsDecoder(fn: "GraphQLParser.floatExn")
+      no_with_veto_vote @bsDecoder(fn: "GraphQLParser.floatExn")
+      abstain_vote @bsDecoder(fn: "GraphQLParser.floatExn")
+      total_bonded_tokens @bsDecoder(fn: "GraphQLParser.floatExn")
       totalDeposit: total_deposit @bsDecoder(fn: "GraphQLParser.coins")
     }
   }
@@ -177,6 +213,11 @@ module SingleConfig = [%graphql
       accountOpt: account @bsRecord {
           address @bsDecoder(fn: "Address.fromBech32")
       }
+      yes_vote @bsDecoder(fn: "GraphQLParser.floatExn")
+      no_vote @bsDecoder(fn: "GraphQLParser.floatExn")
+      no_with_veto_vote @bsDecoder(fn: "GraphQLParser.floatExn")
+      abstain_vote @bsDecoder(fn: "GraphQLParser.floatExn")
+      total_bonded_tokens @bsDecoder(fn: "GraphQLParser.floatExn")
       totalDeposit: total_deposit @bsDecoder(fn: "GraphQLParser.coins")
     }
   }


### PR DESCRIPTION
### Issue: (Jira issue Number or URL)
[https://bandprotocol.atlassian.net/browse/DEXP-768?atlOrigin=eyJpIjoiNWI1ZDA2MWVkNTc3NGEyZTgwYzgyYTZmNmM0ZDM1ZjQiLCJwIjoiaiJ9](https://bandprotocol.atlassian.net/browse/DEXP-768?atlOrigin=eyJpIjoiNWI1ZDA2MWVkNTc3NGEyZTgwYzgyYTZmNmM0ZDM1ZjQiLCJwIjoiaiJ9)

### What is the feature?
 according to [https://github.com/bandprotocol/chain/pull/272](https://github.com/bandprotocol/chain/pull/272)
change the calculation of Turnout when proposal finished


### What is the solution?
- improve ProposalSub to get `yes_vote`, `no_vote`, `no_with_veto_vote`, `abstain_vote` and `total_bonded_tokens`
- in `ProposalIndexPage` check if proposal is finished then choose which data to used to calculated
### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How to test?
Describe the prerequisites and the steps to test

### Screenshots (if any)


### Other Notes
Add any additional information that would be useful to the developer or QA tester
