### PR TITLE
fix: broken interchain query

### DIFF
--- a/src/components/ibcs/IBCTab.re
+++ b/src/components/ibcs/IBCTab.re
@@ -57,18 +57,6 @@ let make = (~direction: IBCQuery.packet_direction_t, ~chainID) => {
   let (packetSequence, setPacketSequence) = React.useState(_ => "");
   let (rawPacketSequence, setRawPacketSequence) = React.useState(_ => "");
 
-  let packetsSub =
-    IBCQuery.getList(
-      ~pageSize=10,
-      ~direction,
-      ~packetType,
-      ~port=packetPort,
-      ~channel=packetChannel,
-      ~sequence=packetSequence |> int_of_string_opt,
-      ~chainID,
-      (),
-    );
-
   let filters = IBCFilterSub.getFilterList(~chainID, ());
 
   let packetTypes = [|
@@ -99,6 +87,18 @@ let make = (~direction: IBCQuery.packet_direction_t, ~chainID) => {
     setPacketSequence(_ => "");
     setRawPacketSequence(_ => "");
   };
+
+    let packetsSub =
+    IBCQuery.getList(
+      ~pageSize=10,
+      ~direction,
+      ~packetType,
+      ~port=packetPort,
+      ~channel=packetChannel,
+      ~sequence=packetSequence |> int_of_string_opt,
+      ~chainID,
+      (),
+    );
 
   React.useEffect1(
     () => {
@@ -193,6 +193,21 @@ let make = (~direction: IBCQuery.packet_direction_t, ~chainID) => {
              </Col>
            )
          ->React.array
+       | Error(_) =>
+         <EmptyContainer backgroundColor={theme.mainBg}>
+           <img
+             alt="No Packets"
+             src={isDarkMode ? Images.noOracleDark : Images.noOracleLight}
+             className=Styles.noDataImage
+           />
+           <Heading
+             size=Heading.H4
+             value="No Packets"
+             align=Heading.Center
+             weight=Heading.Regular
+             color={theme.textSecondary}
+           />
+         </EmptyContainer>
        | _ =>
          Belt_Array.make(10, ApolloHooks.Subscription.NoData)
          ->Belt_Array.mapWithIndex((i, noData) =>

--- a/src/query/IBCQuery.re
+++ b/src/query/IBCQuery.re
@@ -170,7 +170,7 @@ let toExternal =
 };
 module IncomingPacketsConfig = [%graphql
   {|
-    query IncomingPackets($limit: Int!, $packetType: String!, $packetTypeIsNull: Boolean!, $port: String!, $channel: String!, $sequence: Int_comparison_exp, $chainID: String!) {
+  query IncomingPackets($limit: Int!, $packetType: String!, $packetTypeIsNull: Boolean!, $port: String!, $channel: String!, $sequence: Int_comparison_exp, $chainID: String!) {
     incoming_packets(limit: $limit, order_by: {block_height: desc}, where: {type: {_is_null: $packetTypeIsNull, _ilike: $packetType}, sequence: $sequence, dst_port: {_ilike: $port}, dst_channel: {_ilike: $channel}, channel:{connection: {counterparty_chain: {chain_id: {_ilike: $chainID}}}}}) @bsRecord {
         packetType: type @bsDecoder(fn: "parsePacketTypeOpt")
         srcPort: src_port
@@ -196,7 +196,7 @@ module IncomingPacketsConfig = [%graphql
 
 module OutgoingPacketsConfig = [%graphql
   {|
-    query OutgoingPackets($limit: Int!, $packetType: String!, $packetTypeIsNull: Boolean!, $port: String!, $channel: String!, $sequence: Int_comparison_exp, $chainID: String!) {
+  query OutgoingPackets($limit: Int!, $packetType: String!, $packetTypeIsNull: Boolean!, $port: String!, $channel: String!, $sequence: Int_comparison_exp, $chainID: String!) {
     outgoing_packets(limit: $limit, order_by: {block_height: desc}, where: {type: {_is_null: $packetTypeIsNull, _ilike: $packetType}, sequence: $sequence ,src_port: {_ilike: $port}, src_channel: {_ilike: $channel}, channel:{connection: {counterparty_chain: {chain_id: {_ilike: $chainID}}}}}) @bsRecord {
         packetType: type @bsDecoder(fn: "parsePacketTypeOpt")
         srcPort: src_port
@@ -227,6 +227,7 @@ let getList =
     | "Oracle Request" => Some("oracle_request")
     | "Oracle Response" => Some("oracle response")
     | "Fungible Token" => Some("fungible_token")
+    | "Interchain Account" => Some("interchain_account")
     | "Unknown"
     | "" => None
     | _ => raise(Not_found)
@@ -280,6 +281,7 @@ let getList =
                 | Some("oracle_request") => "oracle_request"
                 | Some("oracle response") => "oracle response"
                 | Some("fungible_token") => "fungible_token"
+                | Some("interchain_account") => "interchain_account"
                 | _ => "%%"
                 };
               },
@@ -318,6 +320,7 @@ let getList =
                 | Some("oracle_request") => "oracle_request"
                 | Some("oracle response") => "oracle response"
                 | Some("fungible_token") => "fungible_token"
+                | Some("interchain_account") => "interchain_account"
                 | _ => "%%"
                 };
               },


### PR DESCRIPTION
### Issue: (Jira issue Number or URL)
- https://bandprotocol.atlassian.net/jira/software/projects/DEXP/boards/13?selectedIssue=DEXP-801

### What is the feature?
- Fix bug interchain query
- Show "No packets" if there is no packet tx

### What is the solution?
- Change "oracle_response" to "interchain_account"
- Add Error type for graphql

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How to test?
1. [Go to IBC Page](http://localhost:1234/ibcs)
2. Change Packet Type dropdown to "Interchain Account"
3. Switch the "Incoming" and "Outgoing" tab to see the result
4. There should be "No packets" showing if there's no packets

### Screenshots (if any)


### Other Notes


[DEXP-801]: https://bandprotocol.atlassian.net/browse/DEXP-801?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ