### PR TITLE
fix: update bandchain api

### DIFF
--- a/src/rpc/PriceHook.re
+++ b/src/rpc/PriceHook.re
@@ -33,7 +33,7 @@ let getBandUsd24Change = () => {
 };
 
 let getCirculatingSupply = () => {
-  Axios.get("https://supply.bandchain.org/circulating")
+  Axios.get("https://api.bandchain.org/supply/circulating")
   |> Js.Promise.then_(result => Promise.ret(result##data |> JsonUtils.Decode.float))
   |> Js.Promise.catch(_ => {
        Js.Console.log("swapped to use coingekco api");


### PR DESCRIPTION
### Issue: (Jira issue Number or URL)
-

### What is the feature?
Fix the outdated BandChain API for circulating supply

### What is the solution?
Change the API from `https://supply.bandchain.org/circulating` to `https://api.bandchain.org/supply/circulating`

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How to test?
Go to the homepage, and make sure the market cap is correct

### Screenshots (if any)
<img width="1436" alt="Screen Shot 2566-01-06 at 12 24 49" src="https://user-images.githubusercontent.com/12908129/210936066-bd6d2880-a90c-420c-bd4a-758cf09d1ada.png">


### Other Notes
Add any additional information that would be useful to the developer or QA tester
