### PR TITLE
fix: ol rendering

### DIFF
--- a/src/reusable/Markdown.re
+++ b/src/reusable/Markdown.re
@@ -13,13 +13,14 @@ module Styles = {
           hover([color(theme.baseBlue)]),
         ],
       ),
-      selector("p, ul, ul > li", [color(theme.textSecondary), marginBottom(`em(1.))]),
+      selector("p, ul, ul > li, ol, ol > li", [color(theme.textSecondary), marginBottom(`em(1.))]),
       selector("p:last-child", [color(theme.textSecondary), marginBottom(`em(0.))]),
       selector(
         "h2, h3, h4, h5, h6",
         [color(theme.textSecondary), marginBottom(`px(10)), fontSize(`px(16))],
       ),
       selector("ul", [marginLeft(`em(1.2))]),
+      selector("ol", [marginLeft(`em(2.0)), listStyleType(`decimal)]),
       selector(
         "ul > li",
         [
@@ -39,8 +40,24 @@ module Styles = {
             pointerEvents(`none),
             color(theme.baseBlue),
           ]),
+        ]
+      ),
+      selector(
+        "ol > li",
+        [
+          fontSize(`px(14)),
+          paddingLeft(`px(15)),
+          position(`relative),
+          lineHeight(`em(1.42)),
         ],
       ),
+      selector(
+        "ol > li::marker",
+        [
+          fontFamilies([`custom("Montserrat"), `custom("sans-serif")]),
+          fontVariant(`inherit_)
+        ],
+      )
     ]);
 };
 


### PR DESCRIPTION
### Issue: (Jira issue Number or URL)
- No CSS rendering for `ol` tag

### What is the feature?
Add CSS to support `ol` rendering in markdown

### What is the solution?
Change `list-style` from `unset` to `decimal` and change `font-family` to its corresponding typeface

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How to test?
1. Go to http://localhost:1234/proposal/4

### Screenshots (if any)

From
<img width="835" alt="Screen Shot 2566-01-13 at 19 05 51" src="https://user-images.githubusercontent.com/12908129/212316806-61773310-8eb0-444f-ac91-ea3352284186.png">

Should be
<img width="873" alt="Screen Shot 2566-01-13 at 19 07 21" src="https://user-images.githubusercontent.com/12908129/212316874-c99692f9-94fa-4252-9fba-d6a3ce9061fd.png">


### Other Notes
Add any additional information that would be useful to the developer or QA tester
