### PR TITLE
fix: override pinata url to ipfs

### DIFF
--- a/src/components/oracle-script/OracleScriptCode.re
+++ b/src/components/oracle-script/OracleScriptCode.re
@@ -28,7 +28,24 @@ let renderCode = content => {
 let make = (~url: string) => {
   let ({ThemeContext.theme, isDarkMode}, _) = React.useContext(ThemeContext.context);
 
-  let AxiosHooks.{data: dataOpt, loading} = AxiosHooks.useLoadable(url);
+  let isFromPinata = url |> Js.String.startsWith("https://gateway.pinata.cloud/ipfs/");
+  let AxiosHooks.{data: dataOpt, loading} = {
+    switch (isFromPinata) {
+    | true =>
+      let overrideUrl =
+        url
+        |> Js.String.split("https://gateway.pinata.cloud/ipfs/")
+        |> Belt.Array.get(_, 1)
+        |> Belt.Option.getWithDefault(_, url);
+
+      AxiosHooks.useLoadable("https://ipfs.io/ipfs/"++overrideUrl);
+
+    | _ => AxiosHooks.useLoadable(url)
+    };
+  };
+
+  // let AxiosHooks.{data: dataOpt, loading} = AxiosHooks.useLoadable(url);
+
   let codeOpt = dataOpt |> Belt.Option.flatMap(_, Js.Json.decodeString);
 
   switch (codeOpt, loading) {

--- a/src/rpc/PriceHook.re
+++ b/src/rpc/PriceHook.re
@@ -7,9 +7,13 @@ type t = {
   circulatingSupply: float,
 };
 
+let headers = Axios.Headers.fromObj({"Access-Control-Allow-Origin": "*",
+"Access-Control-Allow-Headers": "*", "Access-Control-Allow-Methods": "*"});
+
 let getBandUsd24Change = () => {
-  Axios.get(
+  Axios.getc(
     "https://api.coingecko.com/api/v3/simple/price?ids=band-protocol&vs_currencies=usd&include_market_cap=true&include_24hr_change=true",
+    Axios.makeConfig(~headers, ())
   )
   |> Js.Promise.then_(result => {
        Promise.ret(
@@ -19,7 +23,8 @@ let getBandUsd24Change = () => {
      })
   |> Js.Promise.catch(_ => {
        Js.Console.log("swapped to use cryptocompare api");
-       Axios.get("https://min-api.cryptocompare.com/data/pricemultifull?fsyms=BAND&tsyms=USD")
+       Axios.getc("https://min-api.cryptocompare.com/data/pricemultifull?fsyms=BAND&tsyms=USD",
+       Axios.makeConfig(~headers, ()))
        |> Js.Promise.then_(result => {
             Promise.ret(
               result##data
@@ -33,7 +38,8 @@ let getBandUsd24Change = () => {
 };
 
 let getCirculatingSupply = () => {
-  Axios.get("https://api.bandchain.org/supply/circulating")
+  Axios.getc("https://api.bandchain.org/supply/circulating",
+  Axios.makeConfig(~headers, ()))
   |> Js.Promise.then_(result => Promise.ret(result##data |> JsonUtils.Decode.float))
   |> Js.Promise.catch(_ => {
        Js.Console.log("swapped to use coingekco api");


### PR DESCRIPTION
### Issue: (Jira issue Number or URL)
-

### What is the feature?
Oracle Script Code URL was not working when it was hosted on `https://gateway.pinata.cloud/ipfs/`

### What is the solution?
Override its URL to `https://ipfs.io/ipfs/` 

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How to test?
[Go to Oracle Script Page and click on Code tab](https://www.cosmoscan.io/oracle-script/23#code)

### Screenshots (if any)
<img width="1249" alt="Screen Shot 2566-01-19 at 09 24 23" src="https://user-images.githubusercontent.com/12908129/213340719-0065dbaa-db68-4918-a9c5-c679aa138fe2.png">


### Other Notes
Since it used Axios-hooks with `useLoadable`, it doesn't have the option to set the headers, otherwise, we need to change it to default axios fetching.
